### PR TITLE
fix duplicate class error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,7 @@ const plugin = (config = {}, ctx) => {
         extendMarkdown: md => {
             rules.map((rule) => {
                 md.renderer.rules[rule] = (tokens, idx, options, env, slf) => {
-                    if (!tokens[idx].attrs) tokens[idx].attrs = []
-                    tokens[idx].attrs.push(['class', `${prefix}-${rule}`])
+                    tokens[idx].attrJoin('class', `${prefix}-${rule}`)
 
                     return slf.renderToken(tokens, idx, options)
                 }


### PR DESCRIPTION
Good sir,

There appears to be a mistake when the token already has a class namely that the token will end up with two class attributes which is invalid.  The `attrJoin` function is much safer to use:

https://markdown-it.github.io/markdown-it/#Token.attrJoin